### PR TITLE
Should be able to set the Readme content from the JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 repos.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,38 +7,34 @@ Ever wanted to include your private repository contributions to your contributio
 ```json
 [
     {
-        "target_repo"  : [
-            "/home/brian/myrepo",
-            "/home/brian/myrepo-old"
-        ],
-        "target_email" : [
-            "brian@example.org",
-            "bob@otherexample.com"
-        ],
-        "dummy_repo"   : "/home/brian/dummy_myrepo",
+        "target_repo"       : ["/home/brian/myrepo","/home/brian/myrepo-old"],
+        "target_email"      : ["brian@example.org","bob@otherexample.com"],
+        "dummy_repo"        : "/home/brian/dummy_myrepo",
         "dummy_repo_data"   : "/home/brian/dummy_myrepo/data",
-        "dummy_email"  : "brian@example.org",
-        "dummy_name"   : "Brian Seymour",
-        "dummy_ext"    : ".js",
-        "dummy_code"   : "'use strict';",
-        "hide_commits" : false,
-        "auto_push"    : true,
-        "force"        : false,
-        "remote"       : "https://github.com/yourname/dummy_repo"
+        "dummy_email"       : "brian@example.org",
+        "dummy_name"        : "Brian Seymour",
+        "dummy_readme"      : "This public repository reflects the commits from a private repo (minus the actual code)",
+        "dummy_ext"         : ".js",
+        "dummy_code"        : "'use strict';",
+        "hide_commits"      : false,
+        "auto_push"         : true,
+        "force"             : false,
+        "remote"            : "https://github.com/yourname/dummy_repo"
     },
     {
-        "target_repo"  : ["/home/brian/myotherprivaterepo"],
-        "target_email" : ["brian@example.org"],
-        "dummy_repo"   : "/home/brian/dummy_myotherprivaterepo",
+        "target_repo"       : ["/home/brian/myotherprivaterepo"],
+        "target_email"      : ["brian@example.org"],
+        "dummy_repo"        : "/home/brian/dummy_myotherprivaterepo",
         "dummy_repo_data"   : "/home/brian/dummy_myotherprivaterepo/data",
-        "dummy_email"  : "brian@example.org",
-        "dummy_name"   : "Brian Seymour",
-        "dummy_ext"    : "",
-        "dummy_code"   : "",
-        "hide_commits" : true,
-        "auto_push"    : true,
-        "force"        : true,
-        "remote"       : "https://github.com/yourname/dummy_privaterepo"
+        "dummy_email"       : "brian@example.org",
+        "dummy_name"        : "Brian Seymour",
+        "dummy_readme"      : "This public repository reflects the commits from a private repo (minus the actual code)",
+        "dummy_ext"         : "",
+        "dummy_code"        : "",
+        "hide_commits"      : true,
+        "auto_push"         : true,
+        "force"             : true,
+        "remote"            : "https://github.com/yourname/dummy_privaterepo"
     }
 ]
 ```
@@ -60,6 +56,9 @@ Here you must provide a new email address the dummy commits will be made as. Thi
 
 ##### Which name should be used in the dummy commits (dummy_name)
 Here you must provide the name the dummy commits will be made as. This really has no bearing, but, it should be your name.
+
+##### What should your readme file contain? (dummy_readme)
+Here you must provide the actual text to the readme file associated to that specific repo
 
 ##### What the file extension for the dummy files be?
 Recommend using whatever primary language your private repo is...

--- a/gitdummy.py
+++ b/gitdummy.py
@@ -18,13 +18,14 @@ def init():
         'init'
     ])
     readme = open(repo['dummy_repo'] + os.path.sep + 'README.md', 'w+')
-    readme.write("This README was generated from GitDummy v3 (oehokie edition)\n")
-    readme.write("This public repository reflects the commits from a private repo (minus the actual code)\n")
-    readme.write("By creating this public repo, the user wanted their public contributions graph to reflect their private work.\n")
-    readme.write("...or at least that's what I wanted to do...\n")
-    readme.write("\n\n")
-    readme.write("If you want to see the user's private repo... ask and maybe they'll show you.")
+    readme.write(repo['dummy_readme'])
     readme.close()
+
+    ignore = open(repo['dummy_repo'] + os.path.sep + '.gitignore', 'w+')
+    ignore.write(".gitdummy\n")
+    ignore.write(".DS_Store\n")
+    ignore.close()
+    
     subprocess.call([
         'git',
         'add',

--- a/repos_sample.json
+++ b/repos_sample.json
@@ -1,36 +1,32 @@
 [
     {
-        "target_repo"  : [
-            "/home/brian/myrepo",
-            "/home/brian/myrepo-old"
-        ],
-        "target_email" : [
-            "brian@example.org",
-            "bob@otherexample.com"
-        ],
-        "dummy_repo"   : "/home/brian/dummy_myrepo",
+        "target_repo"       : ["/home/brian/myrepo","/home/brian/myrepo-old"],
+        "target_email"      : ["brian@example.org","bob@otherexample.com"],
+        "dummy_repo"        : "/home/brian/dummy_myrepo",
         "dummy_repo_data"   : "/home/brian/dummy_myrepo/data",
-        "dummy_email"  : "brian@example.org",
-        "dummy_name"   : "Brian Seymour",
-        "dummy_ext"    : ".js",
-        "dummy_code"   : "'use strict';",
-        "hide_commits" : false,
-        "auto_push"    : true,
-        "force"        : false,
-        "remote"       : "https://github.com/yourname/dummy_repo"
+        "dummy_email"       : "brian@example.org",
+        "dummy_name"        : "Brian Seymour",
+        "dummy_readme"      : "This public repository reflects the commits from a private repo (minus the actual code)",
+        "dummy_ext"         : ".js",
+        "dummy_code"        : "'use strict';",
+        "hide_commits"      : false,
+        "auto_push"         : true,
+        "force"             : false,
+        "remote"            : "https    ://github.com/yourname/dummy_repo"
     },
     {
-        "target_repo"  : ["/home/brian/myotherprivaterepo"],
-        "target_email" : ["brian@example.org"],
-        "dummy_repo"   : "/home/brian/dummy_myotherprivaterepo",
-        "dummy_repo_data"   : "/home/brian/dummy_myotherprivaterepo/data",
-        "dummy_email"  : "brian@example.org",
-        "dummy_name"   : "Brian Seymour",
-        "dummy_ext"    : "",
-        "dummy_code"   : "",
-        "hide_commits" : true,
-        "auto_push"    : true,
-        "force"        : true,
-        "remote"       : "https://github.com/yourname/dummy_privaterepo"
+        "target_repo"       : ["/home/brian/myotherprivaterepo"],
+        "target_email"      : ["brian@example.org"],
+        "dummy_repo"        : "/home/brian/dummy_myotherprivaterepo",
+        "dummy_repo_data"           : "/home/brian/dummy_myotherprivaterepo/data",
+        "dummy_email"       : "brian@example.org",
+        "dummy_name"        : "Brian Seymour",
+        "dummy_readme"      : "This public repository reflects the commits from a private repo (minus the actual code)",
+        "dummy_ext"         : "",
+        "dummy_code"        : "",
+        "hide_commits"      : true,
+        "auto_push"         : true,
+        "force"             : true,
+        "remote"            : "https://github.com/yourname/dummy_privaterepo"
     }
 ]


### PR DESCRIPTION
I added the ability to add custom content in the `readme` file of each repo from the JSON file, through `dummy_readme`.

Also, the script now creates a `.gitignore` file, to ignore files like `.DS_Store` (Mac) and the .gitdummy file. 
