### PR TITLE
Random file names, not from commit messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Ever wanted to include your private repository contributions to your contributio
         "dummy_ext"         : ".js",
         "dummy_code"        : "'use strict';",
         "hide_commits"      : false,
+        "random_file_name"  : false,
         "auto_push"         : true,
         "force"             : false,
         "remote"            : "https://github.com/yourname/dummy_repo"
@@ -32,6 +33,7 @@ Ever wanted to include your private repository contributions to your contributio
         "dummy_ext"         : "",
         "dummy_code"        : "",
         "hide_commits"      : true,
+        "random_file_name"  : true,
         "auto_push"         : true,
         "force"             : true,
         "remote"            : "https://github.com/yourname/dummy_privaterepo"
@@ -49,7 +51,7 @@ Here you must provide the email address the script should search for in the repo
 Here you must provide the absolute path to the folder you want the script to transcribe to. The directory must not exist.
 
 ##### Where should the dummy files be created? (dummy_repo_data)
-Need Files to add... and is used to help with language statistics. (see below)
+Need Files to add... and is used to help with language statistics. To use random file names just set "random_file_name" to true.
 
 ##### Which email address should be used in the dummy commits (dummy_email)
 Here you must provide a new email address the dummy commits will be made as. This will most likely be your GitHub email address so GitHub can properly associate the commits with your account.

--- a/gitdummy.py
+++ b/gitdummy.py
@@ -2,6 +2,8 @@ import os
 import json
 import re
 import subprocess
+import uuid
+import base64
 
 # check for repos.json
 if not os.path.isfile('repos.json'):
@@ -134,6 +136,9 @@ for repo in repos:
             #without this change, for very long commit messages it will throw error: IOError: [Errno 63] File name too long 
             if len(commit['filename']) > 200:
                fullStr =  commit['filename']; commit['filename'] = fullStr[:200]
+
+            if repo['random_file_name']:
+                commit['filename'] = base64.urlsafe_b64encode(uuid.uuid4().bytes).replace('=', '')
 
             os.chdir(repo['dummy_repo_data'])
             if not os.path.isfile(repo['dummy_repo_data'] + os.path.sep + commit['filename'] + repo['dummy_ext']):

--- a/repos_sample.json
+++ b/repos_sample.json
@@ -10,6 +10,7 @@
         "dummy_ext"         : ".js",
         "dummy_code"        : "'use strict';",
         "hide_commits"      : false,
+        "random_file_name"  : false,
         "auto_push"         : true,
         "force"             : false,
         "remote"            : "https    ://github.com/yourname/dummy_repo"
@@ -25,6 +26,7 @@
         "dummy_ext"         : "",
         "dummy_code"        : "",
         "hide_commits"      : true,
+        "random_file_name"  : true,
         "auto_push"         : true,
         "force"             : true,
         "remote"            : "https://github.com/yourname/dummy_privaterepo"


### PR DESCRIPTION
As the default configuration gets the commit message and makes it the file name. I just add an option to use random file names, so no original data is shown at all.