### PR TITLE
Fix duplicate commits on subsequent runs

### DIFF
--- a/gitdummy.py
+++ b/gitdummy.py
@@ -130,6 +130,7 @@ for repo in repos:
                 })
 
     if len(commits) > 0:
+        require_push = False
         for commit in commits:
             private_commit_message = 'Commit message is private'
             
@@ -185,8 +186,9 @@ for repo in repos:
                         '--date',
                         commit['date']
                     ])
+                    require_push = True
 
-        if repo['auto_push'] is True:
+        if repo['auto_push'] is True and require_push is True:
             if repo['force'] is True:
                 subprocess.call([
                     'git',

--- a/gitdummy.py
+++ b/gitdummy.py
@@ -113,13 +113,13 @@ for repo in repos:
 
             commits = []
 
-            for line in log_split:
-                if '||||||||' in line: continue
-                if '||||||||||||' in line: continue
-                if '||||||||||||||||' in line: continue
-                if '||||||||||||||||||||' in line: continue
+            for i in range(1,len(log_split)):
+                if '||||||||' in log_split[i]: continue
+                if '||||||||||||' in log_split[i]: continue
+                if '||||||||||||||||' in log_split[i]: continue
+                if '||||||||||||||||||||' in log_split[i]: continue
 
-                commit_line = line_re.search(line).groups()
+                commit_line = line_re.search(log_split[i]).groups()
 
                 commits.append({
                     'name': commit_line[0],


### PR DESCRIPTION
Issue occurs when `git log --since` would include the last already processed commit and will create another repeated dummy commit.
