### PR TITLE
Safe "git add"

### DIFF
--- a/gitdummy.py
+++ b/gitdummy.py
@@ -166,6 +166,7 @@ for repo in repos:
                     subprocess.call([
                         'git',
                         'add',
+                        '--',
                         commit['filename']+repo['dummy_ext']
                     ])
                     dotgitdummy = open(repo['dummy_repo'] + os.path.sep + '.gitdummy', 'w+')
@@ -174,6 +175,7 @@ for repo in repos:
                     subprocess.call([
                         'git',
                         'add',
+                        '--',
                         repo['dummy_repo'] + os.path.sep + '.gitdummy'
                     ])
                     os.environ['GIT_COMMITTER_DATE'] = commit['date']


### PR DESCRIPTION
Currently there's a problem with the way gitdummy calls `git add`. Here's a problematic example:  

```
...
error: unknown switch `E'
usage: git add [<options>] [--] <pathspec>...

    -n, --dry-run         dry run
    -v, --verbose         be verbose

    -i, --interactive     interactive picking
    -p, --patch           select hunks interactively
    -e, --edit            edit current diff and apply
    -f, --force           allow adding otherwise ignored files
    -u, --update          update tracked files
    -N, --intent-to-add   record only the fact that the path will be added later
    -A, --all             add changes from all tracked and untracked files
    --ignore-removal      ignore paths removed in the working tree (same as --no-all)
    --refresh             don't add, only refresh the index
    --ignore-errors       just skip files which cannot be added because of errors
    --ignore-missing      check if - even missing - files are ignored in dry run

[master 6cfa1f2] -EeevcLtR-6GaBIIKtyWfw Resolved #690: Meta entries now is listing by order.
 Date: Thu Nov 12 02:29:37 2015 +0330
 1 file changed, 1 insertion(+), 1 deletion(-)
PRIVATE COMMIT MESSAGE: -TNfRAuvTC2BBzK_fnu_Hg
Fixed #694: Addressed relay engine bug upon dispatching fake CVs.
error: unknown switch `T'
usage: git add [<options>] [--] <pathspec>...

    -n, --dry-run         dry run
    -v, --verbose         be verbose

    -i, --interactive     interactive picking
    -p, --patch           select hunks interactively
    -e, --edit            edit current diff and apply
    -f, --force           allow adding otherwise ignored files
    -u, --update          update tracked files
    -N, --intent-to-add   record only the fact that the path will be added later
    -A, --all             add changes from all tracked and untracked files
    --ignore-removal      ignore paths removed in the working tree (same as --no-all)
    --refresh             don't add, only refresh the index
    --ignore-errors       just skip files which cannot be added because of errors
    --ignore-missing      check if - even missing - files are ignored in dry run

[master f0ecd91] -TNfRAuvTC2BBzK_fnu_Hg Fixed #694: Addressed relay engine bug upon dispatching fake CVs.
 Date: Sun Nov 15 11:39:31 2015 +0330
 1 file changed, 1 insertion(+), 1 deletion(-)
...
```

This pull requests fixes the issue by using `--` to ensure that commit data won't be confused with git switches.
